### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-
       - name: Run markdown lint
+        uses: actions/checkout@v4
+      - id: get_step
         run: |
             npm install remark-cli remark-preset-lint-consistent
             npx remark . --use remark-preset-lint-consistent --frail


### PR DESCRIPTION
This pull request updates the `.github/workflows/ci.yml` file to improve the sequence of steps in the CI workflow. The most important change involves reordering the `actions/checkout` step to ensure it aligns with the appropriate task.

Changes to CI workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL25-R27): Moved the `actions/checkout@v4` step to precede the `Run markdown lint` task, ensuring the repository is checked out before running linting commands.